### PR TITLE
Fix text to be in `body` not `head`

### DIFF
--- a/Hello World.html
+++ b/Hello World.html
@@ -2,8 +2,8 @@
 <html>
         <head>
             <title></title>
-            Hello World
         </head>
         <body>
-         </body>
+                Hello World
+        </body>
 </html>


### PR DESCRIPTION
The main text that displays on the page should be in `body` not `head`.